### PR TITLE
Add symbolic link creation to mounter script

### DIFF
--- a/jobs/smbdriver-windows/templates/mounter.ps1.erb
+++ b/jobs/smbdriver-windows/templates/mounter.ps1.erb
@@ -1,10 +1,17 @@
-param([String]$username, [String]$password, [String]$remotePath)
+param([String]$username, [String]$password, [String]$remotePath, [String]$localPath)
 
 $ErrorActionPreference = "Stop";
 trap { $host.SetShouldExit(1) }
 
+# mount the remote SMB share globally on the host
 $secpasswd = ConvertTo-SecureString $password -AsPlainText -Force
 $cred = New-Object System.Management.Automation.PSCredential ($username, $secpasswd)
 
 New-SmbGlobalMapping -RemotePath $remotePath -Credential $cred
+
+# create a symbolic link for the container
+$cdir = Split-Path $localPath -Leaf
+$pdir = Split-Path $localPath -Parent
+New-Item -itemtype symboliclink -path $pdir -name $cdir -value $remotePath -Force
+
 Exit 0


### PR DESCRIPTION
This add the symbolic link creation to the powershell script since mklink doesn't exist by default on Windows 1709 cells.

This is the second part to this dependent PR: https://github.com/cloudfoundry/smbdriver/pull/2