### PR TITLE
Bump automake

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -2,10 +2,10 @@ autoconf-2.69.tar.gz:
   size: 1927468
   object_id: f26ccc89-cac6-4ab2-42c6-394b6d8911af
   sha: 562471cbcb0dd0fa42a76665acf0dbb68479b78a
-automake-1.15.tar.gz:
-  size: 2244206
-  object_id: c36c457b-640d-4f34-73dd-da239db8d2fd
-  sha: b5a840c7ec4321e78fdc9472e476263fa6614ca1
+automake-1.15.1.tar.gz:
+  size: 2265200
+  object_id: ef2c1232-3fe8-4362-528e-9214402b3177
+  sha: sha256:988e32527abe052307d21c8ca000aa238b914df363a617e38f4fb89f5abf6260
 cifs-utils-6.7.tar.bz2:
   size: 363647
   object_id: f76fd32c-1c75-4c28-49fd-48ba34a43204

--- a/packages/cifs-utils/packaging
+++ b/packages/cifs-utils/packaging
@@ -14,9 +14,9 @@ pushd autoconf-2.69
   export PATH=${PATH}:${temp_path}/bin
 popd
 
-tar xf automake-1.15.tar.gz
+tar xf automake-1.15.1.tar.gz
 
-pushd automake-1.15
+pushd automake-1.15.1
   ./configure --prefix=${temp_path}
   make
   make install

--- a/packages/cifs-utils/spec
+++ b/packages/cifs-utils/spec
@@ -6,7 +6,7 @@ dependencies:
 
 files:
   - autoconf-2.69.tar.gz
-  - automake-1.15.tar.gz
+  - automake-1.15.1.tar.gz
   - libtool-2.4.6.tar.gz
   - talloc-2.1.9.tar.gz
   - pkg-config-0.29.2.tar.gz


### PR DESCRIPTION
This was mentioned in #42 as being a pre-requisite to make this release work with `bionic`.

This PR only aims to fix the `automake` issue. We will open a new one for `keyutils`.
