### PR TITLE
Fix issue when multiple cf versions are included

### DIFF
--- a/jobs/smbbrokerpush/templates/deploy.sh.erb
+++ b/jobs/smbbrokerpush/templates/deploy.sh.erb
@@ -43,7 +43,7 @@ function authenticate_and_target() {
 function create_credhub_security_group() {
   cf create-security-group credhub_open /var/vcap/jobs/smbbrokerpush/credhub.json
   cf update-security-group credhub_open /var/vcap/jobs/smbbrokerpush/credhub.json
-  if [[ -d "/var/vcap/packages/cf-cli-6-linux" ]]; then
+  if LANG=en cf version | grep "cf version 6" ; then
     cf bind-security-group credhub_open $ORG $SPACE
   else
     cf bind-security-group credhub_open $ORG --space $SPACE


### PR DESCRIPTION
[#182911688]

The previous logic checked whether cf-v6 was installed but that isn't
proof enough that the `cf` command is in fact a symlink to such version.

When multiple versions of `cf` are installed alongside, there is no better
way to know which version is being as the default than doing:
`cf version`