### PR TITLE
Rename golang package to specify only MAJOR version

### DIFF
--- a/dockerfiles/smb-unit-tests/Dockerfile
+++ b/dockerfiles/smb-unit-tests/Dockerfile
@@ -1,7 +1,7 @@
 FROM relintdockerhubpushbot/cf-deployment-concourse-tasks as golang_version
 RUN git clone --recurse-submodules https://github.com/cloudfoundry/smb-volume-release
 RUN cd smb-volume-release && bosh create-release --tarball /tmp/release.tgz
-RUN version=$(cat /tmp/release.tgz | tar -Oxz packages/golang-1.13-linux.tgz | tar z --list | grep -ohE "go[0-9]\.[0-9]{1,2}\.[0-9]{1,2}") && echo $version > /tmp/golang_version
+RUN version=$(cat /tmp/release.tgz | tar -Oxz packages/golang-1-linux.tgz | tar z --list | grep -ohE "go[0-9]\.[0-9]{1,2}\.[0-9]{1,2}") && echo $version > /tmp/golang_version
 RUN ginkgo_version=$(cd smb-volume-release/src/bosh_release/ && go list -f "{{.Version}}" -m github.com/onsi/ginkgo > /tmp/ginkgo_version)
 
 FROM ubuntu

--- a/packages/golang-1-linux/spec.lock
+++ b/packages/golang-1-linux/spec.lock
@@ -1,2 +1,2 @@
-name: golang-1.13-linux
+name: golang-1-linux
 fingerprint: 20234d0cb26adec9565b926f59fa4f7a2ea9e4f230af800fa9a36c8b5f2a8eaa

--- a/packages/smbbroker/packaging
+++ b/packages/smbbroker/packaging
@@ -1,6 +1,6 @@
 set -e
 
-source /var/vcap/packages/golang-1.13-linux/bosh/compile.env
+source /var/vcap/packages/golang-1-linux/bosh/compile.env
 
 mkdir ../src && cp -a * ../src/ && mv ../src ./src
 mkdir $BOSH_INSTALL_TARGET/bin

--- a/packages/smbbroker/spec
+++ b/packages/smbbroker/spec
@@ -2,7 +2,7 @@
 name: smbbroker
 
 dependencies:
-- golang-1.13-linux
+- golang-1-linux
 
 files:
   - code.cloudfoundry.org/smbbroker/**

--- a/packages/smbdriver/packaging
+++ b/packages/smbdriver/packaging
@@ -1,6 +1,6 @@
 set -e
 
-source /var/vcap/packages/golang-1.13-linux/bosh/compile.env
+source /var/vcap/packages/golang-1-linux/bosh/compile.env
 
 mkdir ../src && cp -a * ../src/ && mv ../src ./src
 mkdir $BOSH_INSTALL_TARGET/bin

--- a/packages/smbdriver/spec
+++ b/packages/smbdriver/spec
@@ -2,7 +2,7 @@
 name: smbdriver
 
 dependencies:
-- golang-1.13-linux
+- golang-1-linux
 - cifs-utils
 - smb-debs
 


### PR DESCRIPTION
[#183025303]

As commented in https://github.com/cloudfoundry/nfs-volume-release/pull/198
this has several benefits and aligns with some practices from the golang-release
we depend upon for vendoring go.