### PR TITLE
Be clear about who we cf-auth as when deploying

### DIFF
--- a/jobs/smbbrokerpush/templates/deploy.sh.erb
+++ b/jobs/smbbrokerpush/templates/deploy.sh.erb
@@ -30,8 +30,10 @@ function authenticate_and_target() {
   mkdir -p $CF_HOME
   cf api $API_ENDPOINT <% if p('skip_cert_verify') %>--skip-ssl-validation<% end %>
   <% if_p('cf.client_id', 'cf.client_secret') do |client_id, client_secret| %>
+    echo "Found a client ID. Authenticating cf as <%= client_id %>"
     cf auth "<%= client_id %>" "<%= client_secret %>" --client-credentials
   <% end.else do %>
+    echo "No client ID found. Authenticating cf as <%= p('cf.admin_user') %>"
     cf auth "<%= p('cf.admin_user') %>" "<%= p('cf.admin_password') %>"
   <% end %>
   cf create-org $ORG


### PR DESCRIPTION
In our smbbrokerpush errand, we auth up a CF CLI, and push some apps. There are two options about which user we auth up as.

This PR adds echo lines so that we can see in the task output which user we used to create the `smb` space, and push the app.

[#183259435](https://www.pivotaltracker.com/story/show/183259435)