### PR TITLE
Add force_noserverino property in smbdriver job

### DIFF
--- a/jobs/smbdriver/spec
+++ b/jobs/smbdriver/spec
@@ -79,3 +79,6 @@ properties:
   ssl.insecure_skip_verify:
     description: "When connecting over SSL, skip verification of server IP addresses in the certificate"
     default: false
+  force_noserverino:
+    description: "Force all SMB mounts to use the 'noserverino' mount option. Added to address 'stale file handle' errors after a xenial-to-jammy upgrade."
+    default: false

--- a/jobs/smbdriver/templates/ctl.erb
+++ b/jobs/smbdriver/templates/ctl.erb
@@ -46,6 +46,7 @@ case $1 in
     exec chpst -u root:root /var/vcap/packages/smbdriver/bin/smbdriver \
       --listenPort=<%= p("listen_port") %> \
       --transport="tcp-json" \
+      --forceNoserverino=<%= p("force_noserverino") %> \
       <% if p("tls.ca_cert") != '' %>\
       --requireSSL \
       --certFile="${SERVER_CERTS_DIR}/server.crt" \


### PR DESCRIPTION
We have seen a large deployment in which upgrading from xenial to jammy stemcells caused all apps using SMB mounts to fail with "Stale file handle" errors. This turned out to be because the SMB server was suggesting inode numbers, instead of allowing the client to generate temporary inode numbers.

The fix was to re-bind the SMB service with the mount parameter "noserverino". This new property is intended to allow the platform operator to apply that fix across the whole foundation, rather than relying on application authors to re-bind their SMB services.

[#184474526](https://www.pivotaltracker.com/story/show/184474526)