### PR TITLE
Fix potential cred leak

### DIFF
--- a/jobs/bbr-smbbroker/templates/post-restore-unlock.sh.erb
+++ b/jobs/bbr-smbbroker/templates/post-restore-unlock.sh.erb
@@ -19,9 +19,21 @@ function cf_auth_and_target() {
 
 	set +x
     <% link('smbbrokerpush').if_p('cf.client_id', 'cf.client_secret') do |client_id, client_secret| %>
-        cf auth "<%= client_id %>" "<%= client_secret %>" --client-credentials
+        # On 2023-03-27 we discovered that new stemcells were using OS audit tools to
+        # log every command run on a VM. This was causing CF authentication commands
+        # of the form `cf auth --client-credentials USERNAME PASSWORD` to be logged
+        # in plaintext to syslog.
+        #
+        # Internal shell commands like setting variables are not logged by OS audit
+        # tools, so we changed our auth from passing a password as an argument to
+        # passing a password as an environment variable
+        export CF_USERNAME="<%= client_id %>"
+        export CF_PASSWORD="<%= client_secret %>"
+        cf auth --client-credentials
     <% end.else do %>
-        cf auth "<%= link('smbbrokerpush').p('cf.admin_user') %>" "<%= link('smbbrokerpush').p('cf.admin_password') %>"
+        export CF_USERNAME="<%= link('smbbrokerpush').p('cf.admin_user') %>"
+        export CF_PASSWORD="<%= link('smbbrokerpush').p('cf.admin_password') %>"
+        cf auth
     <% end %>
 	set -x
 	echo -e  "********************\n"

--- a/jobs/smbbrokerpush/templates/deploy.sh.erb
+++ b/jobs/smbbrokerpush/templates/deploy.sh.erb
@@ -31,10 +31,22 @@ function authenticate_and_target() {
   cf api $API_ENDPOINT <% if p('skip_cert_verify') %>--skip-ssl-validation<% end %>
   <% if_p('cf.client_id', 'cf.client_secret') do |client_id, client_secret| %>
     echo "Found a client ID. Authenticating cf as <%= client_id %>"
-    cf auth "<%= client_id %>" "<%= client_secret %>" --client-credentials
+    # On 2023-03-27 we discovered that new stemcells were using OS audit tools to
+    # log every command run on a VM. This was causing CF authentication commands
+    # of the form `cf auth --client-credentials USERNAME PASSWORD` to be logged
+    # in plaintext to syslog.
+    #
+    # Internal shell commands like setting variables are not logged by OS audit
+    # tools, so we changed our auth from passing a password as an argument to
+    # passing a password as an environment variable
+    export CF_USERNAME="<%= client_id %>"
+    export CF_PASSWORD="<%= client_secret %>"
+    cf auth --client-credentials
   <% end.else do %>
     echo "No client ID found. Authenticating cf as <%= p('cf.admin_user') %>"
-    cf auth "<%= p('cf.admin_user') %>" "<%= p('cf.admin_password') %>"
+    export CF_USERNAME="<%= p('cf.admin_user') %>"
+    export CF_PASSWORD="<%= p('cf.admin_password') %>"
+    cf auth
   <% end %>
   cf create-org $ORG
   cf target -o $ORG


### PR DESCRIPTION
On 2023-03-27 we discovered that new stemcells were using OS audit tools to log every command run on a VM. This was causing CF authentication commands of the form `cf auth --client-credentials USERNAME PASSWORD` to be logged in plaintext to syslog.

Internal shell commands like setting variables are not logged by OS audit tools, so this commit changes our auth from passing a password as an argument to passing a password as an environment variable

[#184798214](https://www.pivotaltracker.com/story/show/184798214)