### PR TITLE
avoid leaking creds into syslog/auditlog

### DIFF
--- a/jobs/smbbrokerpush/templates/deploy.sh.erb
+++ b/jobs/smbbrokerpush/templates/deploy.sh.erb
@@ -131,7 +131,22 @@ function push_app() {
 }
 
 function register_service() {
-  cf create-service-broker $SERVICE_BROKER_NAME $USERNAME $PASSWORD $APP_URL || cf update-service-broker $SERVICE_BROKER_NAME $USERNAME $PASSWORD $APP_URL
+  # We want to avoid providing creds as commandline params to binaries to avoid leaking creds via autitd logs. The below `cf curl` replaces the (create|update)-service-broker commands.
+  # cf create-service-broker $SERVICE_BROKER_NAME $USERNAME $PASSWORD $APP_URL || cf update-service-broker $SERVICE_BROKER_NAME $USERNAME $PASSWORD $APP_URL
+
+  number_of_existing_brokers=$(cf curl "/v2/service_brokers?q=name:$SERVICE_BROKER_NAME" | jq '.total_results')
+  if [[ "${number_of_existing_brokers}" -eq "0" ]]; then
+    echo "Creating service broker - name:${SERVICE_BROKER_NAME} host:${APP_URL}"
+    cf curl --fail \
+      -X POST "/v2/service_brokers" \
+      -d@<(echo "{\"auth_username\":\"${USERNAME}\",\"auth_password\":\"${PASSWORD}\",\"broker_url\":\"${APP_URL}\", \"name\": \"${SERVICE_BROKER_NAME}\"}") > /dev/null
+  else
+    echo "Updating service broker - name:${SERVICE_BROKER_NAME} host:${APP_URL}"
+    broker_guid="$(cf curl /v2/service_brokers?q=name:$SERVICE_BROKER_NAME | jq -r '.resources | first | .metadata.guid')"
+    cf curl --fail \
+      -X PUT "/v2/service_brokers/${broker_guid}" \
+      -d@<(echo "{\"auth_username\":\"${USERNAME}\",\"auth_password\":\"${PASSWORD}\",\"broker_url\":\"${APP_URL}\"}") > /dev/null
+  fi
 }
 
 function clean_up() {


### PR DESCRIPTION
when a binary is executed on linux the audit system will log the execution into syslog. This log includes the arguments provided to the binary call. In this script these arguments contain the admin creds for the created service broker.

To avoid this, switch to use echo (a bash builtin) and <() process substition which in turn provides file descriptors. This can then be used with cf curl via the -d param which accepts a path via @ annotation.

The cf cli currently doesn't support sourcing values from the environment
 or config files for this call. To avoid leaking creds while the eature
is missing from the cf cli, this implementation uses cf curl instead. This way the data can be provided through means that will not log cleartext credentials into syslog.