### PR TITLE
avoid leaking creds into syslog/auditlog

### DIFF
--- a/jobs/smbbrokerpush/templates/deploy.sh.erb
+++ b/jobs/smbbrokerpush/templates/deploy.sh.erb
@@ -124,7 +124,22 @@ function push_app() {
 }
 
 function register_service() {
-  cf create-service-broker $SERVICE_BROKER_NAME $USERNAME $PASSWORD $APP_URL || cf update-service-broker $SERVICE_BROKER_NAME $USERNAME $PASSWORD $APP_URL
+  # We want to avoid providing creds as commandline params to binaries to avoid leaking creds via autitd logs. The below `cf curl` replaces the (create|update)-service-broker commands.
+  # cf create-service-broker $SERVICE_BROKER_NAME $USERNAME $PASSWORD $APP_URL || cf update-service-broker $SERVICE_BROKER_NAME $USERNAME $PASSWORD $APP_URL
+  if ! cf curl "/v2/service_brokers?q=name:$SERVICE_BROKER_NAME" | grep $SERVICE_BROKER_NAME; then
+    echo "Creating service broker - name:${SERVICE_BROKER_NAME} host:${APP_URL}"
+    echo "{\"auth_username\":\"${USERNAME}\",\"auth_password\":\"${PASSWORD}\",\"broker_url\":\"${APP_URL}\", \"name\": \"${SERVICE_BROKER_NAME}\"}" > ./data
+    cf curl --fail \
+      -X POST "/v2/service_brokers" \
+      -d @./data
+    rm data
+  else
+    echo "Updating service broker - name:${SERVICE_BROKER_NAME} host:${APP_URL}"
+    broker_guid="$(cf curl /v2/service_brokers?q=name:$SERVICE_BROKER_NAME | grep \"guid\" | cut -f4 -d\")"
+    cf curl --fail \
+      -X PUT "/v2/service_brokers/${broker_guid}" \
+      -d @<(echo "{\"auth_username\":\"${USERNAME}\",\"auth_password\":\"${PASSWORD}\",\"broker_url\":\"${APP_URL}\"}") > /dev/null
+  fi
 }
 
 function clean_up() {

--- a/jobs/smbbrokerpush/templates/manifest.yml.erb
+++ b/jobs/smbbrokerpush/templates/manifest.yml.erb
@@ -9,3 +9,5 @@ applications:
   env:
     USERNAME: "<%= p('username') %>"
     PASSWORD: "<%= p('password') %>"
+    UAA_CLIENT_ID: "<%= p('credhub.uaa_client_id') %>"
+    UAA_CLIENT_SECRET: "<%= p('credhub.uaa_client_secret') %>"

--- a/jobs/smbbrokerpush/templates/start.sh.erb
+++ b/jobs/smbbrokerpush/templates/start.sh.erb
@@ -1,7 +1,5 @@
 bin/smbbroker --listenAddr="0.0.0.0:$PORT" --servicesConfig="./services.json" \
               --credhubURL="<%= p('credhub.url') %>" \
-              --uaaClientID="<%= p('credhub.uaa_client_id') %>" \
-              --uaaClientSecret="<%= p('credhub.uaa_client_secret') %>" \
               --storeID="<%= p('credhub.store_id') %>" \
               --logLevel="<%= p('log_level') %>" \
               --timeFormat="<%= p('log_time_format') %>"

--- a/spec/jobs/smbbrokerpush/start_sh_spec.rb
+++ b/spec/jobs/smbbrokerpush/start_sh_spec.rb
@@ -5,6 +5,37 @@ describe 'smbbrokerpush job' do
   let(:release) { Bosh::Template::Test::ReleaseDir.new(File.join(File.dirname(__FILE__), '../../..')) }
   let(:job) { release.job('smbbrokerpush') }
 
+  describe 'app manifest' do 
+    let(:template) { job.template('manifest.yml') }
+    context 'when fully configured with all required credhub and log properties' do
+      let(:manifest_properties) do
+        {
+            "username" => "admin",
+            "password" => "pass",
+            "app_name" => "broker",
+            "app_domain" => "broker",
+            "memory_in_mb" => "1024",
+            "credhub" => {
+                "url" => "some-credhub-url",
+                "uaa_client_id" => "client-id",
+                "uaa_client_secret" => "client-secret",
+                "store_id" => "some-store-id",
+            },
+            "log_level" => "some-log-level",
+            "log_time_format" => "some-log-time-format",
+        }
+      end
+
+      it 'successfully renders the yml' do
+        tpl_output = template.render(manifest_properties)
+
+        expect(tpl_output).to include("UAA_CLIENT_ID: \"client-id\"")
+        expect(tpl_output).to include("UAA_CLIENT_SECRET: \"client-secret\"")
+      end
+    end
+
+
+  end
   describe 'start.sh' do
     let(:template) { job.template('start.sh') }
 
@@ -28,8 +59,8 @@ describe 'smbbrokerpush job' do
         expect(tpl_output).to include("bin/smbbroker --listenAddr=\"0.0.0.0:$PORT\"")
         expect(tpl_output).to include("--servicesConfig=\"./services.json\"")
         expect(tpl_output).to include("--credhubURL=\"some-credhub-url\"")
-        expect(tpl_output).to include("--uaaClientID=\"client-id\"")
-        expect(tpl_output).to include("--uaaClientSecret=\"client-secret\"")
+        expect(tpl_output).not_to include("--uaaClientID=\"client-id\"")
+        expect(tpl_output).not_to include("--uaaClientSecret=\"client-secret\"")
         expect(tpl_output).to include("--storeID=\"some-store-id\"")
         expect(tpl_output).to include("--logLevel=\"some-log-level\"")
         expect(tpl_output).to include("--timeFormat=\"some-log-time-format\"")
@@ -48,12 +79,12 @@ describe 'smbbrokerpush job' do
         }
       end
 
-      it 'includes the credhub flags in the script' do
+      it 'includes the non sensitive credhub flags in the script' do
         tpl_output = template.render(manifest_properties)
 
         expect(tpl_output).to include("--credhubURL=\"some-credhub-url\"")
-        expect(tpl_output).to include("--uaaClientID=\"some-uaa-client-id\"")
-        expect(tpl_output).to include("--uaaClientSecret=\"some-uaa-client-secret\"")
+        expect(tpl_output).not_to include("--uaaClientID=\"some-uaa-client-id\"")
+        expect(tpl_output).not_to include("--uaaClientSecret=\"some-uaa-client-secret\"")
         expect(tpl_output).to include("--storeID=\"some-store-id\"")
       end
     end


### PR DESCRIPTION
when a binary is executed on linux the audit system will log the execution into syslog. This log includes the arguments provided to the binary call. In this script these arguments contain the admin creds for the created service broker.

To avoid this, switch to use echo (a bash builtin) and <() process substition which in turn provides file descriptors. This can then be used with cf curl via the -d param which accepts a path via @ annotation.

The cf cli currently doesn't support sourcing values from the environment or config files for this call. To avoid leaking creds while the eature is missing from the cf cli, this implementation uses cf curl instead. This way the data can be provided through means that will not log cleartext credentials into syslog.