### PR TITLE
remove python, update dependencies

### DIFF
--- a/.final_builds/packages/python-2.7/index.yml
+++ b/.final_builds/packages/python-2.7/index.yml
@@ -1,6 +1,0 @@
-builds:
-  7063c9f4e43bf49374c2f6cc6c2f74a5467f2298:
-    version: 7063c9f4e43bf49374c2f6cc6c2f74a5467f2298
-    blobstore_id: 3cba5931-06ce-42d4-5d10-6d8575143751
-    sha1: bd130315766a7641dbd20aa328d16f084cc17965
-format-version: "2"

--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -2,18 +2,18 @@ autoconf-2.69.tar.gz:
   size: 1927468
   object_id: f26ccc89-cac6-4ab2-42c6-394b6d8911af
   sha: 562471cbcb0dd0fa42a76665acf0dbb68479b78a
-automake-1.15.1.tar.gz:
-  size: 2265200
-  object_id: ef2c1232-3fe8-4362-528e-9214402b3177
-  sha: sha256:988e32527abe052307d21c8ca000aa238b914df363a617e38f4fb89f5abf6260
-cifs-utils-6.7.tar.bz2:
-  size: 363647
-  object_id: f76fd32c-1c75-4c28-49fd-48ba34a43204
-  sha: 9ba5091d7c2418a90773c861f04a3f4a36854c14
-libtool-2.4.6.tar.gz:
-  size: 1806697
-  object_id: 4c24395e-816f-4d5d-7369-6d5d5fa5741d
-  sha: 25b6931265230a06f0fc2146df64c04e5ae6ec33
+automake-1.16.5.tar.xz:
+  size: 1601740
+  object_id: 8fea41d7-fa88-49fd-40bf-b8997408f54e
+  sha: sha256:f01d58cd6d9d77fbdca9eb4bbd5ead1988228fdb73d6f7a201f5f8d6b118b469
+cifs-utils-7.0.tar.bz2:
+  size: 418638
+  object_id: 96fdc4b7-9cb6-44cf-59db-acc3421c943e
+  sha: sha256:0defaab85bd3ea46ffc45ab41fb0d0ad54d05ae2cfaa7e503de86d4f12bc8161
+libtool-2.4.7.tar.xz:
+  size: 1016040
+  object_id: f690ea15-7d1f-443c-756d-92a776c3ff29
+  sha: sha256:4f7f217f057ce655ff22559ad221a0fd8ef84ad1fc5fcb6990cecc333aa1635d
 pkg-config-0.29.2.tar.gz:
   size: 2016830
   object_id: 17b48507-5868-4826-43ba-14ee1c063907
@@ -26,7 +26,11 @@ smb-debs/jammy/keyutils_1.6.1-2ubuntu3_amd64.deb:
   size: 50410
   object_id: b79af1d3-827b-4dfa-6957-291ec83be991
   sha: sha256:39da334791f57894fa13f680470e048383074b6c02aeb58e206033c5a3d0e925
-talloc-2.1.9.tar.gz:
-  size: 440335
-  object_id: b65fd9d0-6fb6-4d66-68af-e11fc2d8efd2
-  sha: e1e79fec4c0b6bd92be904a9c03b0a168478711a
+talloc-2.4.0.tar.gz:
+  size: 676054
+  object_id: 77e6aa10-7d55-4cba-4bbd-3fa139abf965
+  sha: sha256:6df36862c42466ef88f360444513870ef46934f9016c84383cc4008a7d0c46ba
+xenial-talloc-2.2.0.tar.gz:
+  size: 633467
+  object_id: c2d6a601-cce3-4c3f-7996-964de701834b
+  sha: sha256:5c6f6a45ef96b3fd0b28942673a68d0c6af5dcca9d676a2e4d57ce7e86c22ebc

--- a/packages/cifs-utils/packaging
+++ b/packages/cifs-utils/packaging
@@ -1,54 +1,57 @@
 set -e
 
-source /var/vcap/packages/python-2.7/bosh/compile.env
-
 temp_path=${PWD}/temp
-mkdir $temp_path
+mkdir -p $temp_path
 
-tar xf autoconf-2.69.tar.gz
+tar xf autoconf-*.tar.gz
 
-pushd autoconf-2.69
+pushd autoconf-*/
   ./configure --prefix=${temp_path}
   make
   make install
   export PATH=${PATH}:${temp_path}/bin
 popd
 
-tar xf automake-1.15.1.tar.gz
+tar xf automake-*.tar.xz
 
-pushd automake-1.15.1
+pushd automake-*/
   ./configure --prefix=${temp_path}
   make
   make install
 popd
 
-tar xf libtool-2.4.6.tar.gz
+tar xf libtool*.tar.xz
 
-pushd libtool-2.4.6
+pushd libtool-*/
   ./configure --prefix=${temp_path}
   make
   make install
 popd
 
-tar xf talloc-2.1.9.tar.gz
+tar xf talloc*.tar.gz
 
-pushd talloc-2.1.9
-  ./configure --prefix=${temp_path}
+pushd talloc*/
+  set +e
+  if cat /etc/os-release | grep xenial; then
+    ./configure --prefix=${temp_path} --disable-python
+  else
+    ./configure --prefix=${temp_path}
+  fi
   make
   make install
 popd
 
-tar xf pkg-config-0.29.2.tar.gz
+tar xf pkg-config*.tar.gz
 
-pushd pkg-config-0.29.2
+pushd pkg-config*/
   ./configure --prefix=${temp_path} --with-internal-glib
   make
   make install
 popd
 
-tar jxf cifs-utils-6.7.tar.bz2
+tar jxf cifs-utils*.tar.bz2
 
-pushd cifs-utils-6.7
+pushd cifs-utils*/
   autoreconf -i -I "${temp_path}/share/aclocal"
   ./configure --prefix=${temp_path}
   make CPPFLAGS="-I${temp_path}/include"

--- a/packages/cifs-utils/spec
+++ b/packages/cifs-utils/spec
@@ -1,13 +1,13 @@
 ---
 name: cifs-utils
 
-dependencies:
-- python-2.7
+dependencies: []
 
 files:
-  - autoconf-2.69.tar.gz
-  - automake-1.15.1.tar.gz
-  - libtool-2.4.6.tar.gz
-  - talloc-2.1.9.tar.gz
-  - pkg-config-0.29.2.tar.gz
-  - cifs-utils-6.7.tar.bz2
+  - autoconf-*.tar.gz
+  - automake-*.tar.xz
+  - libtool-*.tar.xz
+  - talloc-*.tar.gz
+  - xenial-talloc-*.tar.gz
+  - pkg-config-*.tar.gz
+  - cifs-utils-*.tar.bz2

--- a/packages/python-2.7/spec.lock
+++ b/packages/python-2.7/spec.lock
@@ -1,2 +1,0 @@
-name: python-2.7
-fingerprint: 7063c9f4e43bf49374c2f6cc6c2f74a5467f2298


### PR DESCRIPTION
[#185232291]

it seems that we do strictly not need python. It was only required as a dependency for talloc, but talloc also comes with a `--disably-python` switch.

manually update all blobs currently in use. Additionally make packaging script work without using static versions to prepare for autobumping them.