### PR TITLE
rupdate xenial talloc to 2.3.1

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -30,7 +30,7 @@ talloc-2.4.0.tar.gz:
   size: 676054
   object_id: 77e6aa10-7d55-4cba-4bbd-3fa139abf965
   sha: sha256:6df36862c42466ef88f360444513870ef46934f9016c84383cc4008a7d0c46ba
-xenial-talloc-2.2.0.tar.gz:
-  size: 633467
-  object_id: c2d6a601-cce3-4c3f-7996-964de701834b
-  sha: sha256:5c6f6a45ef96b3fd0b28942673a68d0c6af5dcca9d676a2e4d57ce7e86c22ebc
+xenial-talloc-2.3.1.tar.gz:
+  size: 638878
+  object_id: edaea656-655c-4259-764b-f33cc309d25d
+  sha: sha256:ef4822d2fdafd2be8e0cabc3ec3c806ae29b8268e932c5e9a4cd5585f37f9f77


### PR DESCRIPTION
starting with 2.3.2 configure is failing with:

```
Checking for python version >= 3.6.0                                              : 3.5.2
The python version is too old, expecting (3, 6, 0)
(complete log in /var/vcap/bosh_ssh/bosh_74558f850a384c8/talloc-2.3.2/bin/config.log)
```

even if you call it will `--disable python`. Later versions do not even provide this helpful error but rather just fail with:

```
Waf: The wscript in '/var/vcap/bosh_ssh/bosh_74558f850a384c8/talloc-2.3.4' is unreadable
Traceback (most recent call last):
  File "/var/vcap/bosh_ssh/bosh_74558f850a384c8/talloc-2.3.4/third_party/waf/waflib/Scripting.py", line 141, in waf_entry_point
    set_main_module(wscript)
  File "/var/vcap/bosh_ssh/bosh_74558f850a384c8/talloc-2.3.4/third_party/waf/waflib/Scripting.py", line 191, in set_main_module
    Context.g_module = Context.load_module(file_path)
  File "/var/vcap/bosh_ssh/bosh_74558f850a384c8/talloc-2.3.4/third_party/waf/waflib/Context.py", line 682, in load_module
    exec(compile(code, path, 'exec'), module.__dict__)
  File "/var/vcap/bosh_ssh/bosh_74558f850a384c8/talloc-2.3.4/wscript", line 17, in <module>
    import wafsamba
  File "./buildtools/wafsamba/wafsamba.py", line 15, in <module>
    from samba_autoconf import *
  File "./buildtools/wafsamba/samba_autoconf.py", line 353
    f'static int test_array[1 - 2 * !((({v})-1) {op} 0)];',
                                                         ^
```