### PR TITLE
use latest available linuxfs  stack for push

### DIFF
--- a/jobs/smbbrokerpush/templates/deploy.sh.erb
+++ b/jobs/smbbrokerpush/templates/deploy.sh.erb
@@ -109,7 +109,7 @@ function push_app() {
 
   mkdir -p /var/vcap/data/tmp
   export TMPDIR=/var/vcap/data/tmp
-  # Find the latest available cflinux stack to ensure that the broker runs with the latest available stack. We could do a more complicated implementation that tries to lookup the default stack and use that, but as of 24-07-2023 I haven't seen a good reason to do so. This way, we will just always use the latest available stack to push the app and not rely on more complicated lookups via cf curl.
+  # Find the latest available cflinux stack to ensure that the broker runs with the latest available stack. We could do a more complicated implementation that tries to lookup the default stack and use that, but as of 24-07-2023 I haven't seen a good reason to do so. This way, we will just always use the latest available stack to push the app and not rely on more complicated lookups via cf curl. Previously this would rely on using the default stack but that only works for new apps. If an app was already pushed with cflinuxfs3 it wouldn't pick up cflinuxfs4 even if that is the default stack. The buildpack (and assigned stack) ordering does NOT affect that either, the stack will be sticky..
   LATEST_STACK = $( cf stacks | grep linux | cut -f1 -d' ' | sort -u | tail -1 )
   pushd /var/vcap/packages/smbbroker > /dev/null
     set +e

--- a/jobs/smbbrokerpush/templates/deploy.sh.erb
+++ b/jobs/smbbrokerpush/templates/deploy.sh.erb
@@ -110,7 +110,7 @@ function push_app() {
   mkdir -p /var/vcap/data/tmp
   export TMPDIR=/var/vcap/data/tmp
   # Find the latest available cflinux stack to ensure that the broker runs with the latest available stack. We could do a more complicated implementation that tries to lookup the default stack and use that, but as of 24-07-2023 I haven't seen a good reason to do so. This way, we will just always use the latest available stack to push the app and not rely on more complicated lookups via cf curl. Previously this would rely on using the default stack but that only works for new apps. If an app was already pushed with cflinuxfs3 it wouldn't pick up cflinuxfs4 even if that is the default stack. The buildpack (and assigned stack) ordering does NOT affect that either, the stack will be sticky..
-  LATEST_STACK = $( cf stacks | grep linux | cut -f1 -d' ' | sort -u | tail -1 )
+  LATEST_STACK=$( cf stacks | grep linux | cut -f1 -d' ' | sort -u | tail -1 )
   pushd /var/vcap/packages/smbbroker > /dev/null
     set +e
     cf push "${APP_NAME}" -i 1 -s ${LATEST_STACK}

--- a/jobs/smbbrokerpush/templates/deploy.sh.erb
+++ b/jobs/smbbrokerpush/templates/deploy.sh.erb
@@ -109,10 +109,11 @@ function push_app() {
 
   mkdir -p /var/vcap/data/tmp
   export TMPDIR=/var/vcap/data/tmp
-
+  # Find the latest available cflinux stack to ensure that the broker runs with the latest available stack. We could do a more complicated implementation that tries to lookup the default stack and use that, but as of 24-07-2023 I haven't seen a good reason to do so. This way, we will just always use the latest available stack to push the app and not rely on more complicated lookups via cf curl.
+  LATEST_STACK = $( cf stacks | grep linux | cut -f1 -d' ' | sort -u | tail -1 )
   pushd /var/vcap/packages/smbbroker > /dev/null
     set +e
-      cf push "${APP_NAME}" -i 1
+    cf push "${APP_NAME}" -i 1 -s ${LATEST_STACK}
       exit_code=$?
     set -e
 


### PR DESCRIPTION
when the platform upgrades stacks from one version to another, and changes the default stack for apps,
then new apps will use the default stack
but existing apps will continue using the previously used stack ( the old one)

We wan't to ensure that the smbbroker is always running with the latest available stack and this commit does just that.

In case of smbbroker we push an app of the same name, thus it isn't considered a new app but rather an existing app which is updated. This means that for smbbroker the new stack will not be picked up because it already has an assigned stack. Unfortunately that means that existing deployments will not get their stack upgraded via the previous version of the push script. It seems that the simplest solution to this is to query the available stack available in CF and then using the latest stack from the output. Piping the output of `cf stacks` through grep and sort should be good enough to achieve this without adding much complexity.

Tested with cfcli v6, v7 and v8.