### PR TITLE
fix race condition

### DIFF
--- a/src/bosh_release/bosh_release_test.go
+++ b/src/bosh_release/bosh_release_test.go
@@ -130,6 +130,11 @@ var _ = Describe("BoshReleaseTest", func() {
 					cmd := exec.Command("bosh", "-d", "bosh_release_test", "ssh", "-c", "rep")
 					_, err := gexec.Start(cmd, GinkgoWriter, GinkgoWriter)
 					Expect(err).NotTo(HaveOccurred())
+					// there's a race condition in CI where the stop is executed before the above ssh was able to be setup and start the process. This should fix it.
+					cmd = exec.Command("bosh", "-d", "bosh_release_test", "ssh", "-c", "until pgrep -x rep; do sleep 1; done")
+					_, err = gexec.Start(cmd, GinkgoWriter, GinkgoWriter)
+					Expect(err).NotTo(HaveOccurred())
+					time.Sleep(10 * time.Second)
 				})
 			})
 


### PR DESCRIPTION
[#185872275]

the tests are being smart and override /bin/sleep to be empty. They're apparently doing so to NOT wait the default 15 mins of the drain script.

the problem was that the `bosh stop` got executed quicker than the fake `rep` process was setup via bosh ssh. this adds a wait for the fake `rep` process.