### PR TITLE
fix regression for DFS exposed SMB Shares

### DIFF
--- a/jobs/smbdriver/templates/pre-start.erb
+++ b/jobs/smbdriver/templates/pre-start.erb
@@ -23,6 +23,12 @@ function main() {
     pushd /var/vcap/packages/cifs-utils/
       cp mount.cifs /sbin/
     popd
+    pushd /var/vcap/packages/keyutils/keyutils
+      cp key.dns_resolver /sbin/
+      cp request-key /sbin/
+      cp request-key.conf /etc
+      mkdir -p /etc/request-key.d
+    popd
 
     echo "Installed mount.cifs"
 


### PR DESCRIPTION
[#187209659]

when this release moved to compile key utils from source it assumed that having the compiled binaries available on PATH is enough for the mount commands to succeed. Unfortunately this is not the case. Some binaries that are compiled with the keyutils source code need to be made available in /sbin.

These binaries are:
- key.dns_resolver
- request-key

When a mount is executed against an SMB share that is exposed within a windows DFS namespace additional calls to these binaries are executed via https://linux.die.net/man/8/cifs.upcall.

Apparently cifs.upcall requires request-key to be present in /sbin as opposed to being available on PATH.

Additionally for request-key to work, it seems that the config folder

- `/etc/request-key.d` needs to exists and the default config
- `/etc/request-key.conf` needs to exist and be populated.

These issues were diagnoses against a windows 2022 server setup to act as

- A domain controller
- A DFS Server
- A file server

the above windows VM exposed an SMB share within its DFS Namespace Root that was created for testing purposes.

The mounts targetting that machines SMB share would not succeed until the above mentioned circumstances were met.