### PR TITLE
Use cf create|update-service-broker to register the service

### DIFF
--- a/jobs/bbr-smbbroker/templates/post-restore-unlock.sh.erb
+++ b/jobs/bbr-smbbroker/templates/post-restore-unlock.sh.erb
@@ -3,8 +3,6 @@
 set -euo pipefail
 set -x
 
-PATH="/var/vcap/packages/cf-cli-6-linux/bin:${PATH}"
-PATH="/var/vcap/packages/cf-cli-7-linux/bin:${PATH}"
 PATH="/var/vcap/packages/cf-cli-8-linux/bin:${PATH}"
 
 API_ENDPOINT=https://api.<%= link('smbbrokerpush').p('domain') %>

--- a/jobs/smbbrokerpush/templates/deploy.sh.erb
+++ b/jobs/smbbrokerpush/templates/deploy.sh.erb
@@ -7,6 +7,9 @@ export PATH="/var/vcap/packages/cf-cli-6-linux/bin:${PATH}"
 export CF_HOME=/var/vcap/data/smbbrokerpush_$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 6 | head -n 1)/
 export CF_DIAL_TIMEOUT=<%= p('cf.dial_timeout') %>
 
+export CF_BROKER_USERNAME="<%= p('username') %>"
+export CF_BROKER_PASSWORD="<%= p('password') %>"
+
 SCHEME=https
 DOMAIN=<%= p('domain') %>
 API_ENDPOINT=$SCHEME://api.$DOMAIN
@@ -20,8 +23,6 @@ MANIFEST=/var/vcap/jobs/smbbrokerpush/manifest.yml
 PROCFILE=/var/vcap/jobs/smbbrokerpush/Procfile
 STARTUP_SCRIPT=/var/vcap/jobs/smbbrokerpush/start.sh
 CREDHUB_CA_CERT=/var/vcap/jobs/smbbrokerpush/credhub_ca.crt
-USERNAME="<%= p('username') %>"
-PASSWORD="<%= p('password') %>"
 APP_URL=$SCHEME://$APP_NAME.$DOMAIN
 
 ERROR_EXIT_CODE=<%= p('error_on_misconfiguration') ? 1 : 0 %>
@@ -131,22 +132,8 @@ function push_app() {
 }
 
 function register_service() {
-  # We want to avoid providing creds as commandline params to binaries to avoid leaking creds via autitd logs. The below `cf curl` replaces the (create|update)-service-broker commands.
-  # cf create-service-broker $SERVICE_BROKER_NAME $USERNAME $PASSWORD $APP_URL || cf update-service-broker $SERVICE_BROKER_NAME $USERNAME $PASSWORD $APP_URL
-  if ! cf curl "/v2/service_brokers?q=name:$SERVICE_BROKER_NAME" | grep $SERVICE_BROKER_NAME; then
-    echo "Creating service broker - name:${SERVICE_BROKER_NAME} host:${APP_URL}"
-    echo "{\"auth_username\":\"${USERNAME}\",\"auth_password\":\"${PASSWORD}\",\"broker_url\":\"${APP_URL}\", \"name\": \"${SERVICE_BROKER_NAME}\"}" > ./data
-    cf curl --fail \
-      -X POST "/v2/service_brokers" \
-      -d @./data
-    rm data
-  else
-    echo "Updating service broker - name:${SERVICE_BROKER_NAME} host:${APP_URL}"
-    broker_guid="$(cf curl /v2/service_brokers?q=name:$SERVICE_BROKER_NAME | grep \"guid\" | cut -f4 -d\")"
-    cf curl --fail \
-      -X PUT "/v2/service_brokers/${broker_guid}" \
-      -d @<(echo "{\"auth_username\":\"${USERNAME}\",\"auth_password\":\"${PASSWORD}\",\"broker_url\":\"${APP_URL}\"}") > /dev/null
-  fi
+  # We want to avoid providing creds as commandline params to binaries to avoid leaking creds via auditd logs. Set the CF_BROKER_PASSWORD instead.
+  cf create-service-broker $SERVICE_BROKER_NAME $CF_BROKER_USERNAME $APP_URL || cf update-service-broker $SERVICE_BROKER_NAME $CF_BROKER_USERNAME $APP_URL
 }
 
 function clean_up() {

--- a/jobs/smbbrokerpush/templates/deploy.sh.erb
+++ b/jobs/smbbrokerpush/templates/deploy.sh.erb
@@ -1,8 +1,6 @@
 #!/bin/bash -eu
 
 export PATH="/var/vcap/packages/cf-cli-8-linux/bin:${PATH}"
-export PATH="/var/vcap/packages/cf-cli-7-linux/bin:${PATH}"
-export PATH="/var/vcap/packages/cf-cli-6-linux/bin:${PATH}"
 
 export CF_HOME=/var/vcap/data/smbbrokerpush_$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 6 | head -n 1)/
 export CF_DIAL_TIMEOUT=<%= p('cf.dial_timeout') %>


### PR DESCRIPTION
- Set the CF_BROKER_PASSWORD env var to eliminate the password from the commands being run.
- This eliminates code that attempts to parse the JSON output from the `/v2/service_brokers` CF API endpoint with `grep` and `cut`, which will no longer work as of [CAPI release v1.183.0](https://github.com/cloudfoundry/capi-release/releases/tag/1.183.0) due to a change in formatting.
- Also remove support for deprecated CF CLI packages.
- TAS only colocates the cf-cli-8-linux package onto the instances that are used to run errands.