### PR TITLE
Update for staticcheck compliant error message

### DIFF
--- a/src/code.cloudfoundry.org/smbbroker/main_test.go
+++ b/src/code.cloudfoundry.org/smbbroker/main_test.go
@@ -488,7 +488,7 @@ var _ = Describe("smbbroker Main", func() {
 
 				responseBody, err := io.ReadAll(resp.Body)
 				Expect(err).NotTo(HaveOccurred())
-				Expect(string(responseBody)).To(ContainSubstring("This service does not support instance updates. Please delete your service instance and create a new one with updated configuration."))
+				Expect(string(responseBody)).To(ContainSubstring("this service does not support instance updates. Please delete your service instance and create a new one with updated configuration"))
 			})
 		})
 	})


### PR DESCRIPTION
- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
code.cloudfoundry.org/existingvolumebroker  had its error message updated, adjusting tests.


Backward Compatibility
---------------
Breaking Change? no