### PR TITLE
cleanup time format property

### DIFF
--- a/jobs/smbbrokerpush/spec
+++ b/jobs/smbbrokerpush/spec
@@ -119,6 +119,3 @@ properties:
   log_level:
     description: "smbbroker log level"
     default: "info"
-  log_time_format:
-    description: "Format for timestamp in component logs. Valid values are 'unix-epoch' and 'rfc3339'."
-    default: "rfc3339"

--- a/jobs/smbbrokerpush/templates/start.sh.erb
+++ b/jobs/smbbrokerpush/templates/start.sh.erb
@@ -2,4 +2,4 @@ bin/smbbroker --listenAddr="0.0.0.0:$PORT" --servicesConfig="./services.json" \
               --credhubURL="<%= p('credhub.url') %>" \
               --storeID="<%= p('credhub.store_id') %>" \
               --logLevel="<%= p('log_level') %>" \
-              --timeFormat="<%= p('log_time_format') %>"
+              --timeFormat=rfc3339

--- a/jobs/smbdriver/spec
+++ b/jobs/smbdriver/spec
@@ -35,9 +35,6 @@ properties:
   log_level:
     description: "smbdriver log level"
     default: "info"
-  log_time_format:
-    description: "Format for timestamp in component logs. Valid values are 'unix-epoch' and 'rfc3339'."
-    default: "rfc3339"
   disable:
     description: "disable smbdriver"
     default: false

--- a/jobs/smbdriver/templates/smbdriver_ctl.erb
+++ b/jobs/smbdriver/templates/smbdriver_ctl.erb
@@ -61,7 +61,7 @@ case $1 in
       --driversPath="<%= p("driver_path") %>" \
       --mountDir="<%= p("cell_mount_path") %>" \
       --logLevel="<%= p("log_level") %>" \
-      --timeFormat="<%= p("log_time_format") %>" \
+      --timeFormat=rfc3339 \
       >> $LOG_DIR/smbdriver.stdout.log \
       2>> $LOG_DIR/smbdriver.stderr.log
     ;;

--- a/spec/jobs/smbbrokerpush/start_sh_spec.rb
+++ b/spec/jobs/smbbrokerpush/start_sh_spec.rb
@@ -22,7 +22,6 @@ describe 'smbbrokerpush job' do
                 "store_id" => "some-store-id",
             },
             "log_level" => "some-log-level",
-            "log_time_format" => "some-log-time-format",
         }
       end
 
@@ -49,7 +48,6 @@ describe 'smbbrokerpush job' do
                 "store_id" => "some-store-id",
             },
             "log_level" => "some-log-level",
-            "log_time_format" => "some-log-time-format",
         }
       end
 
@@ -63,7 +61,6 @@ describe 'smbbrokerpush job' do
         expect(tpl_output).not_to include("--uaaClientSecret=\"client-secret\"")
         expect(tpl_output).to include("--storeID=\"some-store-id\"")
         expect(tpl_output).to include("--logLevel=\"some-log-level\"")
-        expect(tpl_output).to include("--timeFormat=\"some-log-time-format\"")
       end
     end
 

--- a/spec/jobs/smbdriver/start_sh_spec.rb
+++ b/spec/jobs/smbdriver/start_sh_spec.rb
@@ -17,7 +17,6 @@ describe 'smbdriver job' do
             "driver_path" => "/some/driver/path",
             "cell_mount_path" => "/some/cell/mount/path",
             "log_level" => "some-log-level",
-            "log_time_format" => "some-log-level-format",
             "allowed_in_mount" => "some,options",
             "default_in_mount" => "some,default,options",
             "enable_unique_volume_ids" => true,
@@ -40,7 +39,6 @@ describe 'smbdriver job' do
         expect(tpl_output).to include("--driversPath=\"/some/driver/path\"")
         expect(tpl_output).to include("--mountDir=\"/some/cell/mount/path\"")
         expect(tpl_output).to include("--logLevel=\"some-log-level\"")
-        expect(tpl_output).to include("--timeFormat=\"some-log-level-format\"")
         expect(tpl_output).to include("--requireSSL")
         expect(tpl_output).to include("/server.crt")
         expect(tpl_output).to include("/server.key")
@@ -61,7 +59,6 @@ describe 'smbdriver job' do
             "driver_path" => "/some/driver/path",
             "cell_mount_path" => "/some/cell/mount/path",
             "log_level" => "some-log-level",
-            "log_time_format" => "some-log-level-format",
             "allowed_in_mount" => "some,options",
             "default_in_mount" => "some,default,options",
             "enable_unique_volume_ids" => true,


### PR DESCRIPTION
- [ ] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
cleanup time format property

Backward Compatibility
---------------
Breaking Change? **No**
<!---
If this is a breaking change, or modifies currently expected behaviors of core functionality

- Has the change been mitigated to be backwards compatible?
- Should this feature be considered experimental for a period of time, and allow operators to opt-in?
- Should this apply immediately to all deployments?
-->
