### PR TITLE
add validation to user supplied mount options

### DIFF
--- a/src/code.cloudfoundry.org/smbdriver/smb_mounter_unix.go
+++ b/src/code.cloudfoundry.org/smbdriver/smb_mounter_unix.go
@@ -146,12 +146,23 @@ var AllowedMountOptions = []string{"mfsymlinks", "username", "password", "file_m
 func NewSmbVolumeMountMask() (vmo.MountOptsMask, error) {
 	defaultMap := map[string]interface{}{}
 
+	valueValidator := vmo.UserOptsValidationFunc(func(key, value string) error {
+		if strings.Contains(value, ",") {
+			return fmt.Errorf("mount option '%s' contains invalid character ','", key)
+		}
+		if strings.Contains(value, "=") {
+			return fmt.Errorf("mount option '%s' contains invalid character '='", key)
+		}
+		return nil
+	})
+
 	return vmo.NewMountOptsMask(
 		AllowedMountOptions,
 		defaultMap,
 		map[string]string{"readonly": "ro", "version": "vers"},
 		[]string{"source", "mount"},
 		[]string{"username", "password"},
+		valueValidator,
 	)
 
 }

--- a/src/code.cloudfoundry.org/smbdriver/smb_mounter_unix_test.go
+++ b/src/code.cloudfoundry.org/smbdriver/smb_mounter_unix_test.go
@@ -340,6 +340,29 @@ var _ = Describe("SmbMounter", func() {
 				Expect(err.Error()).To(ContainSubstring("Missing mandatory options: password"))
 			})
 		})
+
+		Context("when mount option values contain invalid characters", func() {
+			It("should reject values containing comma", func() {
+				opts["domain"] = "CORP,credentials=/etc/passwd"
+				err = subject.Mount(env, "source", "target", opts)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("contains invalid character ','"))
+			})
+
+			It("should reject values containing equals", func() {
+				opts["sec"] = "ntlm=sign"
+				err = subject.Mount(env, "source", "target", opts)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("contains invalid character '='"))
+			})
+
+			It("should allow legitimate values without special characters", func() {
+				opts["domain"] = "CORP"
+				opts["vers"] = "2.1"
+				err = subject.Mount(env, "source", "target", opts)
+				Expect(err).NotTo(HaveOccurred())
+			})
+		})
 	})
 
 	Context("#Unmount", func() {


### PR DESCRIPTION
- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
adds validation

Backward Compatibility
---------------
Breaking Change? mo